### PR TITLE
explicitly register the coffee-script compiler

### DIFF
--- a/hubble
+++ b/hubble
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-require("coffee-script");
+require("coffee-script/register");
 
 require ('./src/index.coffee')


### PR DESCRIPTION
1.7.0 – JANUARY 28, 2014
When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with require 'coffee-script/register' or CoffeeScript.register(). Also for configuration such as Mocha's, use coffee-script/register.
